### PR TITLE
Add docker builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build/MyApps:
+	mkdir -p build
+	docker run -e BUILD_TARGET=RELEASE -e DSC_PATH=MyApps/MyApps.dsc --rm -v $(PWD):/home/edk2/src -v $(PWD)/build:/home/edk2/Build xaionaro2/edk2-builder:vUDK2017
+	find build/ -name *.efi
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ To integrate into UDK2017 source tree:
   utilities, fix up MyApps.dsc to build the required utility or utilities by uncommening one or more .inf
   lines.
 
+Or you can just build the tools using docker:
+```
+make
+```
+
 Note these utilities have only been built and tested on an X64 platform.
 
 I now include a 64-bit EFI binary of each utility in each utility subdirectory.


### PR DESCRIPTION
Just adding a `Makefile` which uses docker to do not require EDK2 from end users.